### PR TITLE
Floating point numbers support

### DIFF
--- a/momentjs-business.js
+++ b/momentjs-business.js
@@ -8,7 +8,7 @@
   moment = (typeof require !== "undefined" && require !== null) &&
            !require.amd ? require("moment") : this.moment;
 
-  moment.fn.businessDiff = function (param) {
+  moment.fn.businessDiff = function (param, float) {
     param = moment(param);
     var signal = param.unix() < this.unix()?1:-1;
     var start = moment.min(param, this).clone();
@@ -18,7 +18,7 @@
 
     var end_sunday = end.clone().subtract('d', end_offset);
     var start_sunday = start.clone().subtract('d', start_offset);
-    var weeks = end_sunday.diff(start_sunday, 'days') / 7;
+    var weeks = end_sunday.diff(start_sunday, 'days', !!float) / 7;
 
     start_offset = Math.abs(start_offset);
     if(start_offset == 7)


### PR DESCRIPTION
"By default, moment#diff will return a number rounded towards zero (down for positive, up for negative). If you want a floating point number, pass true as the third argument. Before 2.0.0, moment#diff returned a number rounded to nearest, not a rounded number rounded towards zero."

```js
var a = moment([2008, 6]);
var b = moment([2007, 0]);
a.diff(b, 'years');       // 1
a.diff(b, 'years', true); // 1.5
```